### PR TITLE
bug/os-106 boot disk fallback

### DIFF
--- a/playtronos/airootfs/root/install.sh
+++ b/playtronos/airootfs/root/install.sh
@@ -144,10 +144,15 @@ do
 		device_list+=("$description")
 	done <<< "$device_output"
 
+	# NOTE: each disk entry consists of 2 elements in the array (disk name & disk description)
 	if [ "${#device_list[@]}" -gt 2 ]; then
 		DISK=$(whiptail --nocancel --menu "Choose a disk to install $OS_NAME on:" 20 70 5 "${device_list[@]}" 3>&1 1>&2 2>&3)
-	else
+	elif [ "${#device_list[@]}" -eq 2 ]; then
+		# skip selection menu if only a single disk is available to choose from
 		DISK=${device_list[0]}
+	else
+		whiptail --msgbox "No candidate installation disk found.\n\nPlease connect a 64 GB or larger disk and start the installer again." 12 70
+		cancel_install
 	fi
 
 	DISK_DESC=$(get_disk_human_description $DISK)

--- a/playtronos/airootfs/root/install.sh
+++ b/playtronos/airootfs/root/install.sh
@@ -146,7 +146,7 @@ do
 		# skip selection menu if only a single disk is available to choose from
 		DISK=${device_list[0]}
 	else
-		whiptail --msgbox "No candidate installation disk found.\n\nPlease connect a 64 GB or larger disk and start the installer again." 12 70
+		whiptail --msgbox "Could not find a disk to install to.\n\nPlease connect a 64 GB or larger disk and start the installer again." 12 70
 		cancel_install
 	fi
 

--- a/playtronos/airootfs/root/install.sh
+++ b/playtronos/airootfs/root/install.sh
@@ -14,14 +14,12 @@ DEVICE_VENDOR=$(cat /sys/devices/virtual/dmi/id/sys_vendor)
 DEVICE_PRODUCT=$(cat /sys/devices/virtual/dmi/id/product_name)
 DEVICE_CPU=$(lscpu | grep Vendor | cut -d':' -f2 | xargs echo -n)
 
-init_gamepad_support() {
-	echo "Initializing gamepad support..."
+poll_gamepad() {
 	modprobe xpad > /dev/null
 	systemctl start inputplumber > /dev/null
 
-	# wait up to 10 seconds for an input plumber controller device
-	for i in $(seq 1 100); do
-		sleep 0.1
+	while true; do
+		sleep 1
 		busctl call org.shadowblip.InputPlumber \
 			/org/shadowblip/InputPlumber/CompositeDevice0 \
 			org.shadowblip.Input.CompositeDevice \
@@ -112,12 +110,9 @@ cancel_install() {
     exit 1
 }
 
+# start polling for a gamepad
+poll_gamepad &
 
-init_gamepad_support
-
-# fail on error only after gamepad support initialization
-# otherwise installer fails if inputplumber fails to start
-set -e
 
 while true
 do

--- a/playtronos/efiboot/loader/entries/archiso-x86_64-linux.conf
+++ b/playtronos/efiboot/loader/entries/archiso-x86_64-linux.conf
@@ -4,4 +4,4 @@
 title   Install PlaytronOS
 linux   /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-chimeraos
 initrd  /%INSTALL_DIR%/boot/x86_64/initramfs-linux-chimeraos.img
-options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% nomodeset splash quiet
+options archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% nomodeset splash quiet nowatchdog


### PR DESCRIPTION
After an investigation it was determined that there was an issue with the logic that attempts to identify the boot disk.

In some cases, the boot disk information is not formatted as expected. This causes the boot disk to not be identified and the variable to be empty. In a subsequent step, when we remove the boot disk from the list of options, this ends up removing all disk options and the install fails thinking there is no disk available to install to.

The solution is to detect when we are not parsing the boot disk correctly and do not attempt to remove the boot disk from the list of disks in such cases. i.e. I added a fall back in case we cannot get the boot disk since it is not the worst thing if the boot disk is in the disk listing. This will cover any possible cases in the future. I was not able to reproduce this myself (initially thinking the issue was because I used an external SSD for development and testing) even after purchasing a flash disk to test with, so have not added any parsing of additional formats.


This PR also has some additional fixes:
 - explicitly handle the case where there is no disk to install to
 - poll for gamepads in the background instead of making the user wait
 - disable watchdog to avoid superfluous messages on screen during shutdown


Testing performed:
 - [x] should show boot disk in disk selection list when parsing boot disk fails (tested by modifying the install script to fail parsing the boot disk)
 - [x] should show an error message when there are no disks found (tested by modifying the install script to exclude all disks on my system)
 - [x] should skip disk selection step when there is only a single disk found (tested by modifying the install script to exclude all disks on my system except one)
 - [x] should show disk selection menu when multiple disks are found
 - [x] should be able to use a controller even if plugging it in after the installer has started 