### PR TITLE
Remove Community repository

### DIFF
--- a/playtronos/pacman.conf.template
+++ b/playtronos/pacman.conf.template
@@ -79,12 +79,6 @@ Include = /etc/pacman.d/mirrorlist
 [extra]
 Include = /etc/pacman.d/mirrorlist
 
-#[community-testing]
-#Include = /etc/pacman.d/mirrorlist
-
-[community]
-Include = /etc/pacman.d/mirrorlist
-
 # If you want to run 32 bit applications on your x86_64 system,
 # enable the multilib repositories as required here.
 


### PR DESCRIPTION
Arch Linux has finally removed this repository. With it enabled, the ISO build failed because Pacman could not update repository cache for the non-existent Community repository.